### PR TITLE
pyproject: move to poetry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       run: pip install typing
 
     - name: Install build backend
-      run: pip install flit-core
+      run: pip install poetry
 
     - name: Build python-build
       run: python -m build -x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,50 @@
 [build-system]
-requires = ['flit_core >=2,<3']
-build-backend = 'flit_core.buildapi'
+requires = ['poetry>=0.12']
+build-backend = 'poetry.masonry.api'
 
-[tool.flit.metadata]
-module = 'build'
-author = 'Filipe Laíns'
-author-email = 'lains@archlinux.org'
-home-page = 'https://github.com/FFY00/python-build'
-description-file = 'README.md'
-requires = [
-    'toml',
-    'pep517',
-    'packaging',
-    'importlib_metadata;python_version<"3.8"',
-    'typing;python_version<"3"',
+[tool.poetry]
+name = 'build'
+version = '0.0.3.1'
+description = 'A simple, correct PEP517 package builder'
+license = 'MIT'
+
+authors = ['Filipe Laíns <lains@archlinux.org>']
+maintainers = [
+    'Filipe Laíns <lains@archlinux.org>'
 ]
+
+homepage = 'https://github.com/FFY00/python-build'
+repository = 'https://github.com/FFY00/python-build'
+documentation = 'https://python-build.readthedocs.io/en/stable/'
+readme = 'docs/source/index.rst'
+
 classifiers = [
     'License :: OSI Approved :: MIT License',
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3',
 ]
 
-[tool.flit.metadata.requires-extra]
-test = [
-    'pytest',
-    'pytest-mock',
-    'pytest-cov',
+packages = [
+    { include = 'build' },
 ]
 
-[tool.flit.scripts]
+
+[tool.poetry.dependencies]
+# https://github.com/python-poetry/poetry/issues/2542
+#python = [
+#    '2.7',
+#    '>=3.5',
+#]
+toml = '^0.10'
+pep517 = '^0.8'
+packaging = '^20.0'
+importlib-metadata = { version = '^1.0', markers = 'python_version<"3.8"' }
+typing = { version = '^3.0', markers = 'python_version<"3"' }
+
+[tool.poetry.dev-dependencies]
+pytest = '^5.0'
+pytest-mock = '^3.0'
+pytest-cov = '^2.0'
+
+[tool.poetry.scripts]
 python-build = 'build.__main__:main'


### PR DESCRIPTION
Flit doesn't allow us to specify the packages/modules to install.

Signed-off-by: Filipe Laíns <lains@archlinux.org>