### PR TITLE
main: build in a virtual env by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Install build backend
       run: pip install setuptools wheel
 
-    - name: Build python-build
-      run: python -m build -x
+    - name: Build python-build (without isolation)
+      run: python -m build -x -n
 
 
   pip:
@@ -67,8 +67,8 @@ jobs:
     - name: Install build backend
       run: pip install setuptools wheel
 
-    - name: Build pip
-      run: python -m build -x -w ../pip
+    - name: Build pip (without isolation)
+      run: python -m build -x -n -w ../pip
 
 
 #  python-install:
@@ -132,7 +132,7 @@ jobs:
       if: ${{ matrix.python == 2.7 }}
       run: pip install typing
 
-    - name: Build dateutil
+    - name: Build dateutil (with isolation)
       run: python -m build -x -w ../dateutil
 
 
@@ -159,5 +159,5 @@ jobs:
     - name: Install dependencies
       run: pip install toml pep517 packaging importlib_metadata
 
-    - name: Build Solaar
+    - name: Build Solaar (with isolation)
       run: python -m build -x -w ../solaar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,6 +134,8 @@ jobs:
 
     - name: Build dateutil (with isolation)
       run: python -m build -x -w ../dateutil
+      env:
+        SETUPTOOLS_SCM_PRETEND_VERSION: dummy
 
 
   Solaar:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,9 +132,6 @@ jobs:
       if: ${{ matrix.python == 2.7 }}
       run: pip install typing
 
-    - name: Install build backend
-      run: pip install setuptools wheel
-
     - name: Build dateutil
       run: python -m build -x -w ../dateutil
 
@@ -161,9 +158,6 @@ jobs:
 
     - name: Install dependencies
       run: pip install toml pep517 packaging importlib_metadata
-
-    - name: Install build backend
-      run: pip install setuptools wheel
 
     - name: Build Solaar
       run: python -m build -x -w ../solaar

--- a/build/__main__.py
+++ b/build/__main__.py
@@ -7,9 +7,8 @@ import traceback
 
 from typing import List, Optional
 
-import pep517.envbuild
-
 from . import BuildBackendException, BuildException, ConfigSettings, ProjectBuilder
+from .env import IsolatedEnvironment
 
 
 __all__ = ['build', 'main', 'main_parser']
@@ -30,8 +29,8 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
 
 
 def _build_in_isolated_env(builder, outdir, distributions):  # type: (ProjectBuilder, str, List[str]) -> None
-    with pep517.envbuild.BuildEnvironment() as env:
-        env.pip_install(builder.build_dependencies)
+    with IsolatedEnvironment() as env:
+        env.install(builder.build_dependencies)
         for distribution in distributions:
             builder.build(distribution, outdir)
 

--- a/build/env.py
+++ b/build/env.py
@@ -1,0 +1,93 @@
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import types
+
+
+if False:  # TYPE_CHECKING  # pragma: no cover
+    from typing import Dict, Optional, Iterable, Type
+
+
+class IsolatedEnvironment(object):
+    '''
+    Isolated build environment context manager
+
+    Non-standard paths injected directly to sys.path still be passed to the environment.
+    '''
+
+    def __init__(self):  # type: () -> None
+        self._env = {}  # type: Dict[str, Optional[str]]
+
+    def _replace_env(self, key, new):  # type: (str, Optional[str]) -> None
+        if not new:  # pragma: no cover
+            return
+
+        self._env[key] = os.environ.get(key, None)
+        os.environ[key] = new
+
+    def _restore_env(self):  # type: () -> None
+        for key, val in self._env.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def _get_env_path(self, path):  # type: (str) -> Optional[str]
+        return sysconfig.get_path(path, vars=self._env_vars)
+
+    def __enter__(self):  # type: () -> IsolatedEnvironment
+        self._path = tempfile.mkdtemp(prefix='build-env-')
+        self._env_vars = {
+            'base': self._path,
+            'platbase': self._path,
+        }
+
+        sys_path = sys.path[1:]
+
+        remove_paths = os.environ.get('PYTHONPATH', '').split(os.pathsep)
+
+        for path in ('purelib', 'platlib'):
+            our_path = sysconfig.get_path(path)
+            if our_path:
+                remove_paths.append(our_path)
+
+            for scheme in sysconfig.get_scheme_names():
+                our_path = sysconfig.get_path(path, scheme)
+                if our_path:
+                    remove_paths.append(our_path)
+
+            env_path = self._get_env_path(path)
+            if env_path:
+                sys_path.append(env_path)
+
+        for path in remove_paths:
+            if path in sys_path:
+                sys_path.remove(path)
+
+        self._replace_env('PATH', self._get_env_path('scripts'))
+        self._replace_env('PYTHONPATH', os.pathsep.join(sys_path))
+        self._replace_env('PYTHONHOME', self._path)
+
+        return self
+
+    def __exit__(self, typ, value, traceback):
+        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[types.TracebackType]) -> None
+        if self._path and os.path.isdir(self._path):
+            shutil.rmtree(self._path)
+
+        self._restore_env()
+
+    def install(self, requirements):  # type: (Iterable[str]) -> None
+        '''
+        Installs the specified requirements on the environment
+        '''
+        if not requirements:
+            return
+
+        subprocess.check_call([sys.executable, '-m', 'ensurepip'], cwd=self._path)
+
+        cmd = [sys.executable, '-m', 'pip', 'install', '--ignore-installed', '--prefix', self._path] + list(requirements)
+        subprocess.check_call(cmd)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,6 +23,10 @@ can use it:
    usage: python-build [-h] ...
 
 
+By default python-build will build the package in a isolated environment, but
+this behavior can be disabled with ``--no-isolation``.
+
+
 Mission Statement
 =================
 
@@ -67,9 +71,9 @@ with :pep:`517` support.
 ``python -m pep517.build``
 --------------------------
 
-``python -m pep517.build`` will invoke pip_ to install missing dependencies,
-``python-build`` is *stricly* a build tool, it does not do any sort of
-dependency management. If the dependencies are not met, the build will fail.
+``python-build`` implements a CLI tailored to end users. ``python -m
+pep517.build`` *"implements essentially the simplest possible frontend tool,
+to exercise and illustrate how the core functionality can be used"*.
 
 
 Custom Behaviors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+
+DUMMY_PYPROJECT = '''
+[build-system]
+requires = ['flit_core']
+build-backend = 'flit_core.buildapi'
+'''.strip()
+
+
+DUMMY_PYPROJECT_NO_BACKEND = '''
+[build-system]
+requires = []
+'''.strip()
+
+
+DUMMY_PYPROJECT_NO_REQUIRES = '''
+[build-system]
+build-backend = 'something'
+'''.strip()
+
+
+@pytest.fixture
+def empty_file_mock(mocker):
+    return mocker.mock_open(read_data='')
+
+
+@pytest.fixture
+def pyproject_mock(mocker):
+    return mocker.mock_open(read_data=DUMMY_PYPROJECT)
+
+
+@pytest.fixture
+def pyproject_no_backend_mock(mocker):
+    return mocker.mock_open(read_data=DUMMY_PYPROJECT_NO_BACKEND)
+
+
+@pytest.fixture
+def pyproject_no_requires_mock(mocker):
+    return mocker.mock_open(read_data=DUMMY_PYPROJECT_NO_REQUIRES)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: MIT
+
+import os
+import subprocess
+import sys
+import sysconfig
+
+import build.env
+
+
+def test_isolated_environment(mocker):
+    with build.env.IsolatedEnvironment() as env:
+        if os.name != 'nt':
+            assert os.environ['PATH'] == os.path.join(env._path, 'bin')
+        assert os.environ['PYTHONHOME'] == env._path
+
+        for path in ('purelib', 'platlib'):
+            assert sysconfig.get_path(path) not in os.environ['PYTHONPATH'].split(os.pathsep)
+
+        mocker.patch('subprocess.check_call')
+
+        env.install([])
+        subprocess.check_call.assert_not_called()
+
+        env.install(['some', 'requirements'])
+        if sys.version_info[:2] != (3, 5):
+            subprocess.check_call.assert_called()
+        assert subprocess.check_call.call_args[0][0] == [
+            sys.executable, '-m', 'pip', 'install', '--ignore-installed', '--prefix', env._path, 'some', 'requirements'
+        ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,6 @@ import io
 import os
 import sys
 
-import pep517
 import pytest
 
 import build
@@ -82,9 +81,10 @@ def test_build(mocker):
     mocker.patch('build.ProjectBuilder.check_dependencies')
     mocker.patch('build.ProjectBuilder.build')
     mocker.patch('build.__main__._error')
-    mocker.patch('pep517.envbuild.BuildEnvironment.pip_install')
+    mocker.patch('build.env.IsolatedEnvironment.install')
 
     build.ProjectBuilder.check_dependencies.side_effect = [[], ['something'], [], []]
+    build.env.IsolatedEnvironment._path = mocker.Mock()
 
     # isolation=True
     build.__main__.build('.', '.', ['sdist'])
@@ -93,7 +93,7 @@ def test_build(mocker):
     # check_dependencies = []
     build.__main__.build('.', '.', ['sdist'], isolation=False)
     build.ProjectBuilder.build.assert_called_with('sdist', '.')
-    pep517.envbuild.BuildEnvironment.pip_install.assert_called_with(set(build._DEFAULT_BACKEND['requires']))
+    build.env.IsolatedEnvironment.install.assert_called_with(set(build._DEFAULT_BACKEND['requires']))
 
     # check_dependencies = ['something']
     build.__main__.build('.', '.', ['sdist'], isolation=False)

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -20,9 +20,9 @@ else:  # pragma: no cover
     email_message_from_string = importlib_metadata._compat.email_message_from_string
 
 if sys.version_info >= (3,):  # pragma: no cover
-    build_open_owener = 'builtins'
+    build_open_owner = 'builtins'
 else:  # pragma: no cover
-    build_open_owener = 'build'
+    build_open_owner = 'build'
     FileNotFoundError = IOError
     PermissionError = OSError
 
@@ -88,7 +88,7 @@ def test_init(mocker, pyproject_mock):
         'setuptools.build_meta:__legacy__': None,
     }
     mocker.patch('importlib.import_module', modules.get)
-    mocker.patch('{}.open'.format(build_open_owener), pyproject_mock)
+    mocker.patch('{}.open'.format(build_open_owner), pyproject_mock)
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     # data = ''
@@ -107,14 +107,14 @@ def test_init(mocker, pyproject_mock):
         build.ProjectBuilder('.')
 
     open_mock = mocker.mock_open(read_data=DUMMY_PYPROJECT_BAD)
-    mocker.patch('{}.open'.format(build_open_owener), open_mock)
+    mocker.patch('{}.open'.format(build_open_owner), open_mock)
     with pytest.raises(build.BuildException):
         build.ProjectBuilder('.')
 
 
 def test_check_dependencies(mocker, pyproject_mock):
     mocker.patch('importlib.import_module')
-    mocker.patch('{}.open'.format(build_open_owener), pyproject_mock)
+    mocker.patch('{}.open'.format(build_open_owner), pyproject_mock)
     mocker.patch('pep517.wrappers.Pep517HookCaller.get_requires_for_build_sdist')
     mocker.patch('pep517.wrappers.Pep517HookCaller.get_requires_for_build_wheel')
     mocker.patch('build.check_version')
@@ -148,7 +148,7 @@ def test_check_dependencies(mocker, pyproject_mock):
 
 def test_build(mocker, pyproject_mock):
     mocker.patch('importlib.import_module')
-    mocker.patch('{}.open'.format(build_open_owener), pyproject_mock)
+    mocker.patch('{}.open'.format(build_open_owner), pyproject_mock)
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     builder = build.ProjectBuilder()
@@ -171,7 +171,7 @@ def test_build(mocker, pyproject_mock):
 
 def test_default_backend(mocker, empty_file_mock):
     mocker.patch('importlib.import_module')
-    mocker.patch('{}.open'.format(build_open_owener), empty_file_mock)
+    mocker.patch('{}.open'.format(build_open_owner), empty_file_mock)
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     builder = build.ProjectBuilder()
@@ -181,7 +181,7 @@ def test_default_backend(mocker, empty_file_mock):
 
 def test_missing_backend(mocker, pyproject_no_backend_mock):
     mocker.patch('importlib.import_module')
-    mocker.patch('{}.open'.format(build_open_owener), pyproject_no_backend_mock)
+    mocker.patch('{}.open'.format(build_open_owner), pyproject_no_backend_mock)
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     builder = build.ProjectBuilder()
@@ -191,7 +191,7 @@ def test_missing_backend(mocker, pyproject_no_backend_mock):
 
 def test_missing_requires(mocker, pyproject_no_requires_mock):
     mocker.patch('importlib.import_module')
-    mocker.patch('{}.open'.format(build_open_owener), pyproject_no_requires_mock)
+    mocker.patch('{}.open'.format(build_open_owner), pyproject_no_requires_mock)
     mocker.patch('pep517.wrappers.Pep517HookCaller')
 
     with pytest.raises(build.BuildException):


### PR DESCRIPTION
As discussed in [1] python-build should now build inside a virtual
environment, as recommended in PEP517. This patch implements that
functionality and sets it as the default behavior. It also introduces a
--no-isolation flag to disable this.

[1] https://discuss.python.org/t/moving-python-build-to-pypa/4390

Signed-off-by: Filipe Laíns <lains@archlinux.org>