### PR TITLE
build: raise BuildException when fail to parse pyproject.toml

### DIFF
--- a/build/__init__.py
+++ b/build/__init__.py
@@ -13,6 +13,7 @@ from typing import Set
 
 import pep517.wrappers
 import toml
+import toml.decoder
 
 
 if sys.version_info < (3,):  # pragma: no cover
@@ -84,6 +85,8 @@ class ProjectBuilder(object):
             self._spec = {}
         except PermissionError as e:
             raise BuildException("{}: '{}' ".format(e.strerror, e.filename))
+        except toml.decoder.TomlDecodeError as e:
+            raise BuildException("Failed to parse pyproject.toml: {} ".format(e))
 
         try:
             self._build_system = self._spec['build-system']

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -7,6 +7,7 @@ import sys
 
 import pep517.wrappers
 import pytest
+import toml.decoder
 
 import build
 
@@ -41,7 +42,7 @@ build-backend = 'flit_core.buildapi'
 
 DUMMY_PYPROJECT_BAD = '''
 [build-system]
-build-backend = 'missing_backend'
+requires = ['bad' 'syntax']
 '''.strip()
 
 
@@ -104,6 +105,11 @@ def test_init(mocker):
 
     # PermissionError
     open_mock.side_effect = PermissionError
+    with pytest.raises(build.BuildException):
+        build.ProjectBuilder('.')
+
+    open_mock = mocker.mock_open(read_data=DUMMY_PYPROJECT_BAD)
+    mocker.patch('{}.open'.format(build_open_owener), open_mock)
     with pytest.raises(build.BuildException):
         build.ProjectBuilder('.')
 


### PR DESCRIPTION
The toml backtrace is still available for API consumers if they want it.

Signed-off-by: Filipe Laíns <lains@archlinux.org>