### PR TITLE
build: fix typo in ProjectBuilder.get_dependencies()

### DIFF
--- a/build/__init__.py
+++ b/build/__init__.py
@@ -120,7 +120,7 @@ class ProjectBuilder(object):
         except Exception as e:  # noqa: E722
             raise BuildBackendException('Backend operation failed: {}'.format(e))
 
-    def check_depencencies(self, distribution):  # type: (str) -> Set[str]
+    def check_dependencies(self, distribution):  # type: (str) -> Set[str]
         '''
         Returns a set of the missing dependencies
 

--- a/build/__main__.py
+++ b/build/__main__.py
@@ -41,7 +41,7 @@ def build(srcdir, outdir, distributions, skip_dependencies=False):  # type: (str
 
         for dist in distributions:
             if not skip_dependencies:
-                missing = builder.check_depencencies(dist)
+                missing = builder.check_dependencies(dist)
                 if missing:
                     _error('Missing dependencies:' + ''.join(['\n\t' + dep for dep in missing]))
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,11 +57,11 @@ def test_build(mocker):
     open_mock = mocker.mock_open(read_data='')
     mocker.patch('{}.open'.format(build_open_owner), open_mock)
     mocker.patch('importlib.import_module')
-    mocker.patch('build.ProjectBuilder.check_depencencies')
+    mocker.patch('build.ProjectBuilder.check_dependencies')
     mocker.patch('build.ProjectBuilder.build')
     mocker.patch('build.__main__._error')
 
-    build.ProjectBuilder.check_depencencies.side_effect = [[], ['something'], [], []]
+    build.ProjectBuilder.check_dependencies.side_effect = [[], ['something'], [], []]
 
     # check_dependencies = []
     build.__main__.build('.', '.', ['sdist'])

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -135,18 +135,18 @@ def test_check_dependencies(mocker):
     builder.hook.get_requires_for_build_wheel.side_effect = copy.copy(side_effects)
 
     # requires = []
-    assert not builder.check_depencencies('sdist')
-    assert not builder.check_depencencies('wheel')
+    assert not builder.check_dependencies('sdist')
+    assert not builder.check_dependencies('wheel')
 
     # requires = ['something']
-    assert builder.check_depencencies('sdist')
-    assert builder.check_depencencies('wheel')
+    assert builder.check_dependencies('sdist')
+    assert builder.check_dependencies('wheel')
 
     # BackendUnavailable
     with pytest.raises(build.BuildBackendException):
-        builder.check_depencencies('sdist')
+        builder.check_dependencies('sdist')
     with pytest.raises(build.BuildBackendException):
-        not builder.check_depencencies('wheel')
+        not builder.check_dependencies('wheel')
 
 
 @pytest.mark.skipif(sys.version_info[:2] == (3, 5), reason='bug in mock')


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>