### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/lib/
+dist/
+*.egg-info/
+.eggs
+
+# Documentation
+docs/srcbuild/
+
+# Testing and coverage
+.cache
+.nox/
+.mypy_cache/
+.pytest_cache
+htmlcov/
+.coverage
+coverage.xml


### PR DESCRIPTION
Picking up from #29, I think we definitely need a `.gitignore`. I agree with @FFY00 about IDE-related stuff going in global `.gitignore`, though I think my list of stuff we should ignore is longer than his.

I've started with something based on what gets generated when I run `nox` in a clean build.