### PR TITLE
nox: add pytest-mock dependency

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -34,6 +34,6 @@ def test(session):
     htmlcov_output = os.path.join(session.virtualenv.location, 'htmlcov')
 
     session.install('.', 'importlib_metadata')
-    session.install('pytest', 'pytest-cov')
+    session.install('pytest', 'pytest-cov', 'pytest-mock')
 
     session.run('pytest', '--cov', f'--cov-report=html:{htmlcov_output}', 'tests/', *session.posargs)


### PR DESCRIPTION
Without this, `nox` fails.

If we're going to have a `noxfile.py`, I think it should be used in the CI as well, so that we can expect contributors to be able to just run `nox` or `nox -s test-3.8` or whatever and it should always work.

Here's how I typically do it when I use `tox` in my projects: https://github.com/pganssle/zoneinfo/blob/4299bfd7623934acc6f27b32744b02a147912120/.github/workflows/python-tests.yml#L5-L32

I think that you'd do something similar by parameterizing over `NOXSESSION`.