### PR TITLE
env: keep original PATH

### DIFF
--- a/src/build/env.py
+++ b/src/build/env.py
@@ -116,7 +116,15 @@ class IsolatedEnvironment(object):
             if path in sys_path:
                 sys_path.remove(path)
 
-        self._replace_env('PATH', self._get_env_path('scripts'))
+        env_scripts = self._get_env_path('scripts')
+        if env_scripts is None:  # pragma: no cover
+            raise RuntimeError('Missing scripts directory in sysconfig')
+
+        exe_path = [env_scripts]
+        if 'PATH' in os.environ:
+            exe_path.append(os.environ['PATH'])
+
+        self._replace_env('PATH', os.pathsep.join(exe_path))
         self._replace_env('PYTHONPATH', os.pathsep.join(sys_path))
         self._replace_env('PYTHONHOME', self._path)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -9,9 +9,10 @@ import build.env
 
 
 def test_isolated_environment(mocker):
+    old_path = os.environ['PATH']
     with build.env.IsolatedEnvironment() as env:
         if os.name != 'nt':
-            assert os.environ['PATH'] == os.path.join(env._path, 'bin')
+            assert os.environ['PATH'] == os.pathsep.join([os.path.join(env._path, 'bin'), old_path])
         assert os.environ['PYTHONHOME'] == env._path
 
         for path in ('purelib', 'platlib'):


### PR DESCRIPTION
This is required so that we can find programs such as GCC.

Signed-off-by: Filipe Laíns <lains@archlinux.org>