### PR TITLE
build: include build system dependencies in check_dependencies

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -142,6 +142,7 @@ class ProjectBuilder(object):
         :param distribution: Distribution to build (sdist or wheel)
         '''
         dependencies = self.get_dependencies(distribution)
+        dependencies.update(self.build_dependencies)
 
         return {dep for dep in dependencies if not check_version(dep)}
 

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -132,8 +132,8 @@ def test_check_dependencies(mocker, pyproject_mock):
     builder.hook.get_requires_for_build_wheel.side_effect = copy.copy(side_effects)
 
     # requires = []
-    assert not builder.check_dependencies('sdist')
-    assert not builder.check_dependencies('wheel')
+    assert builder.check_dependencies('sdist') == {'flit_core'}
+    assert builder.check_dependencies('wheel') == {'flit_core'}
 
     # requires = ['something']
     assert builder.check_dependencies('sdist')


### PR DESCRIPTION
Fixes #64

Signed-off-by: Filipe Laíns <lains@archlinux.org>