### PR TITLE
Detach interpreter introspection from other logic

### DIFF
--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -41,7 +41,7 @@ def _error(msg, code=1):  # type: (str, int) -> None  # pragma: no cover
 
 
 def _build_in_isolated_env(builder, outdir, distributions):  # type: (ProjectBuilder, str, List[str]) -> None
-    with IsolatedEnvironment() as env:
+    with IsolatedEnvironment.for_current() as env:
         env.install(builder.build_dependencies)
         for distribution in distributions:
             builder.build(distribution, outdir)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -12,7 +12,7 @@ import build.env
 
 def test_isolated_environment_setup(mocker):
     old_path = os.environ['PATH']
-    with build.env.IsolatedEnvironment() as env:
+    with build.env.IsolatedEnvironment.for_current() as env:
         if os.name != 'nt':
             assert os.environ['PATH'] == os.pathsep.join([os.path.join(env.path, 'bin'), old_path])
         assert os.environ['PYTHONHOME'] == env.path
@@ -54,7 +54,7 @@ def test_isolated_environment_setup(mocker):
 
 
 def test_isolated_environment_install(mocker):
-    with build.env.IsolatedEnvironment() as env:
+    with build.env.IsolatedEnvironment.for_current() as env:
         mocker.patch('subprocess.check_call')
 
         env.install([])
@@ -70,7 +70,7 @@ def test_isolated_environment_install(mocker):
 
 
 def test_uninitialised_isolated_environment():
-    env = build.env.IsolatedEnvironment()
+    env = build.env.IsolatedEnvironment.for_current()
 
     with pytest.raises(RuntimeError):
         env.path


### PR DESCRIPTION
This makes it easier to reuse IsolatedEnvironment on environments other than the current intrepreter, and likely also would make it easier to test since the introspection rules can not be more easily mocked.