### PR TITLE
ci: disable fail-fast

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,6 +12,7 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python: [2.7, 3.5, 3.6, 3.7, 3.8]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ jobs:
   pytest:
     runs-on: ${{ matrix.platform }}-latest
     strategy:
+      fail-fast: false
       matrix:
         platform:
         - ubuntu


### PR DESCRIPTION
This makes the CI run all jobs even if one failed. This way we can see
exactly all of the breakage.

Signed-off-by: Filipe Laíns <lains@archlinux.org>