### PR TITLE
ci: always upload coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
       run: nox -s test-${{ matrix.python }} -- --run-integration
 
     - name: Send coverage report
+      if: ${{ always() }}
       uses: codecov/codecov-action@v1
       env:
         PYTHON: ${{ matrix.python }}


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>