### PR TITLE
build: create output directory if missing

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -176,6 +176,12 @@ class ProjectBuilder(object):
         '''
         build = getattr(self.hook, 'build_{}'.format(distribution))
 
+        if os.path.exists(outdir):
+            if not os.path.isdir(outdir):
+                raise BuildException("Build path '{}' exists and is not a directory".format(outdir))
+        else:
+            os.mkdir(outdir)
+
         try:
             build(outdir, self.config_settings)
         except Exception as e:  # noqa: E722

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -185,3 +185,28 @@ def test_build_system_typo(mocker, test_typo):
 
     with pytest.warns(build.TypoWarning):
         build.ProjectBuilder(test_typo)
+
+
+def test_missing_outdir(mocker, tmp_dir, test_flit_path):
+    mocker.patch('importlib.import_module')
+    mocker.patch('pep517.wrappers.Pep517HookCaller')
+
+    builder = build.ProjectBuilder(test_flit_path)
+    out = os.path.join(tmp_dir, 'out')
+
+    builder.build('sdist', out)
+
+    assert os.path.isdir(out)
+
+
+def test_not_dir_outdir(mocker, tmp_dir, test_flit_path):
+    mocker.patch('importlib.import_module')
+    mocker.patch('pep517.wrappers.Pep517HookCaller')
+
+    builder = build.ProjectBuilder(test_flit_path)
+    out = os.path.join(tmp_dir, 'out')
+
+    open(out, 'a').close()  # create empty file
+
+    with pytest.raises(build.BuildException):
+        builder.build('sdist', out)


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>