### PR TITLE
build: do not check for the backend in when using in-tree backends

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -133,10 +133,11 @@ class ProjectBuilder(object):
 
         self._backend = self._build_system['build-backend']
 
-        try:
-            importlib.import_module(self._backend.split(':')[0])
-        except ImportError:  # can't mock importlib.import_module  # pragma: no cover
-            raise BuildException("Backend '{}' is not available".format(self._backend))
+        if 'backend-path' not in self._build_system:
+            try:
+                importlib.import_module(self._backend.split(':')[0])
+            except ImportError:  # can't mock importlib.import_module  # pragma: no cover
+                raise BuildException("Backend '{}' is not available".format(self._backend))
 
         self.hook = pep517.wrappers.Pep517HookCaller(self.srcdir, self._backend,
                                                      backend_path=self._build_system.get('backend-path'))

--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -136,7 +136,7 @@ class ProjectBuilder(object):
         if 'backend-path' not in self._build_system:
             try:
                 importlib.import_module(self._backend.split(':')[0])
-            except ImportError:  # can't mock importlib.import_module  # pragma: no cover
+            except ImportError:
                 raise BuildException("Backend '{}' is not available".format(self._backend))
 
         self.hook = pep517.wrappers.Pep517HookCaller(self.srcdir, self._backend,

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 import copy
+import importlib
 import os
 import sys
 
@@ -96,6 +97,15 @@ def test_init(mocker, test_flit_path, legacy_path, test_no_permission, test_bad_
     # TomlDecodeError
     with pytest.raises(build.BuildException):
         build.ProjectBuilder(test_bad_syntax_path)
+
+    mocker.patch('importlib.import_module')
+    importlib.import_module.side_effect = ImportError
+
+    # ImportError
+    with pytest.raises(build.BuildException):
+        build.ProjectBuilder(test_flit_path)
+    with pytest.raises(build.BuildException):
+        build.ProjectBuilder(test_flit_path)
 
 
 def test_check_dependencies(mocker, test_flit_path):


### PR DESCRIPTION
Right now we are trying to check for in-tree backends, which obviously
won't work.

We only have this check to provide nicer error messages to users, I
don't see the need to provide the same "nicer" error messages when using
in-tree backends as it is quite niche.

In these cases, pep517 will raise an error and we will print it.

Signed-off-by: Filipe Laíns <lains@archlinux.org>