### PR TITLE
tests: integration: test building flit_core 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ INTEGRATION_SOURCES = {
     'dateutil': ('dateutil/dateutil', '2.8.1'),
     'pip': ('pypa/pip', '20.2.1'),
     'Solaar': ('pwr-Solaar/Solaar', '1.0.3'),
+    'flit': ('takluyver/flit', '2.3.0'),
 }
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -21,6 +21,7 @@ _WHEEL = re.compile('.*.whl')
         'pip',
         'dateutil',
         'Solaar',
+        os.path.join('flit', 'flit_core')
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
flit_core uses an in-tree backend

Signed-off-by: Filipe Laíns <lains@archlinux.org>