### PR TITLE
setup.cfg: add trove classifieres for CPython and PyPy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
 project_urls =
     homepage = https://github.com/FFY00/python-build
 


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>