### PR TITLE
build: fix calling hooks with relative output directory

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -201,6 +201,7 @@ class ProjectBuilder(object):
         :param outdir: Outpur directory
         '''
         build = getattr(self.hook, 'build_{}'.format(distribution))
+        outdir = os.path.abspath(outdir)
 
         if os.path.exists(outdir):
             if not os.path.isdir(outdir):


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>