### PR TITLE
readme: add an install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ A simple, correct PEP517 package builder.
 
 See the [documentation](https://python-build.readthedocs.io/en/latest/) for more information.
 
+### Installation
+
+`python-build` can be installed via `pip` or an equivalent via:
+
+  ```
+  $ pip install build
+  ```
+
 ### Code of Conduct
 
 Everyone interacting in the python-build's codebase, issue trackers, chat


### PR DESCRIPTION
Hi! (Congrats on the release).

Perhaps it's useful to add an installation command to the README, mostly considering that `python-build` on PyPI is an [unrelated thing](https://pypi.org/project/python-build/) so folks need to know this has a distribution name of just `build`.