### PR TITLE
Couple of docs tweaks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
 
     - name: Install mypy
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: checks
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+
+    - name: Install nox
+      run: |
+        pip install nox
+        nox --version
+
+    - name: Build the documentation
+      run: nox -s docs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,15 +29,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
     - name: Set up target Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
 
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
 
     - name: Install pytest
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
 
-    - name: Install pytest
+    - name: Install nox
       run: |
         pip install nox
         nox --version

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,6 @@ repos:
   rev: v4.3.21
   hooks:
   - id: isort
-- repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.5.1
-  hooks:
-  - id: rst-backticks
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v1.9.0
   hooks:

--- a/docs/source/build.rst
+++ b/docs/source/build.rst
@@ -1,0 +1,21 @@
+build package
+=============
+
+Submodules
+----------
+
+build.env module
+----------------
+
+.. automodule:: build.env
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: build
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,8 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+default_role = 'any'
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,11 +45,17 @@ we will try to keep dependencies to a minimum, in order to try make
 bootstrapping easier.
 
 
-Releases
-========
+Installation & Releases
+=======================
 
 You can download a tarball_ from Github, checkout the latest `git tag`_ or fetch
 the artifacts from `project page`_ on PyPI.
+
+``python-build`` may also be installed via `pip`_ or an equivalent:
+
+.. code-block:: sh
+
+   $ pip install build
 
 The recommended way is to checkout the git tags, as they are PGP signed with one
 of the following keys:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,8 +23,8 @@ can use it:
    usage: python-build [-h] ...
 
 
-By default python-build will build the package in a isolated environment, but
-this behavior can be disabled with :option:`--no-isolation`.
+By default python-build will build the package in a isolated
+environment, but this behavior can be disabled with `--no-isolation`.
 
 
 Mission Statement
@@ -99,8 +99,8 @@ Bootstrapping
 =============
 
 This package can build itself with only the ``toml`` and ``pep517``
-dependencies. The :option:`--skip-dependencies` flag should be used in
-this case.
+dependencies. The `--skip-dependencies` flag should be used in this
+case.
 
 
 Compability

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,13 +9,13 @@ python-build will invoke the :pep:`517` hooks to build a distribution package.
 It is a simple build tool, it does no dependency management.
 
 
-The recommended way to invoke is by calling the module:
+The recommended way to invoke it is by calling the module:
 
 .. autoprogram:: build.__main__:main_parser()
    :prog: python -m build
 
 
-But the ``python-build`` script is also available, so that tools such as pipx_
+A ``python-build`` script is also available, so that tools such as pipx_
 can use it:
 
 .. code-block:: sh

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,9 +77,12 @@ with :pep:`517` support.
 ``python -m pep517.build``
 --------------------------
 
-``python-build`` implements a CLI tailored to end users. ``python -m
-pep517.build`` *"implements essentially the simplest possible frontend tool,
-to exercise and illustrate how the core functionality can be used"*.
+``python-build`` implements a CLI tailored to end users.
+
+``pep517.build`` contained a proof-of-concept of a :pep:`517`
+frontend. It *"implement[ed] essentially the simplest possible frontend
+tool, to exercise and illustrate how the core functionality can be
+used"*. It has since been `deprecated and is scheduled for removal`_.
 
 
 Custom Behaviors
@@ -130,6 +133,8 @@ versions:
 .. _tarball: https://github.com/FFY00/python-build/releases
 .. _git tag: https://github.com/FFY00/python-build/tags
 .. _project page: https://pypi.org/project/build/
+
+.. _deprecated and is scheduled for removal: https://github.com/pypa/pep517/pull/83
 
 
 .. |3DCE51D60930EBA47858BA4146F633CBB0EB4BF2| replace:: ``3DCE51D60930EBA47858BA4146F633CBB0EB4BF2``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ can use it:
 
 
 By default python-build will build the package in a isolated environment, but
-this behavior can be disabled with ``--no-isolation``.
+this behavior can be disabled with :option:`--no-isolation`.
 
 
 Mission Statement
@@ -99,7 +99,8 @@ Bootstrapping
 =============
 
 This package can build itself with only the ``toml`` and ``pep517``
-dependencies. The ``--skip-dependencies`` flag should be used in this case.
+dependencies. The :option:`--skip-dependencies` flag should be used in
+this case.
 
 
 Compability

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -110,6 +110,8 @@ versions:
 - 3.6
 - 3.7
 - 3.8
+- PyPy(2)
+- PyPy3
 
 
 ``build`` module

--- a/noxfile.py
+++ b/noxfile.py
@@ -39,6 +39,13 @@ def test_pythonpath(session):
     run_tests(session, env={'PYTHONPATH': 'src'})
 
 
+@nox.session(python='3.8')
+def docs(session):
+    session.install('.', '-r', 'docs/requirements.txt')
+    output = session.create_tmp()
+    session.run('python', '-m', 'sphinx', '-n', '-W', 'docs/source', output)
+
+
 @nox.session(python=['2.7', '3.5', '3.6', '3.7', '3.8', 'pypy2', 'pypy3'])
 def test_wheel(session):
     session.install('-r', 'requirements-dev.txt')

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,8 +13,9 @@ nox.options.reuse_existing_virtualenvs = True
 def mypy(session):
     session.install('.', 'mypy')
 
-    session.run('mypy', 'src/build')
-    session.run('mypy', '--py2', 'src/build')
+    srcbuild = os.path.join('src', 'build')
+    session.run('mypy', srcbuild)
+    session.run('mypy', '--py2', srcbuild)
 
 
 def run_tests(session, env=None):
@@ -41,9 +42,12 @@ def test_pythonpath(session):
 
 @nox.session(python='3.8')
 def docs(session):
-    session.install('.', '-r', 'docs/requirements.txt')
+    session.install('.', '-r', os.path.join('docs', 'requirements.txt'))
     output = session.create_tmp()
-    session.run('python', '-m', 'sphinx', '-n', '-W', 'docs/source', output)
+    session.run(
+        'python', '-m', 'sphinx',
+        '-n', '-W', os.path.join('docs', 'source'), output,
+    )
 
 
 @nox.session(python=['2.7', '3.5', '3.6', '3.7', '3.8', 'pypy2', 'pypy3'])

--- a/src/build/__main__.py
+++ b/src/build/__main__.py
@@ -98,7 +98,7 @@ def main_parser():  # type: () -> argparse.ArgumentParser
     out = os.path.join(cwd, 'dist')
     parser = argparse.ArgumentParser()
     parser.add_argument('srcdir',
-                        type=str, nargs='?', metavar='.', default=cwd,
+                        type=str, nargs='?', metavar='sourcedir', default=cwd,
                         help='source directory (defaults to current directory)')
     parser.add_argument('--sdist', '-s',
                         action='store_true',

--- a/src/build/env.py
+++ b/src/build/env.py
@@ -6,9 +6,7 @@ import sysconfig
 import tempfile
 import types
 
-
-if False:  # TYPE_CHECKING  # pragma: no cover
-    from typing import Dict, Optional, Iterable, Sequence, Type
+from typing import Dict, Iterable, Optional, Sequence, Type
 
 
 if sys.version_info[0] == 2:  # pragma: no cover


### PR DESCRIPTION
- Adds the install command from #94 to the Sphinx docs
- Fixes the warnings from building the docs, including populating the missing API documentation
- Builds docs in CI more strictly than RTD to catch bugs such as the above
- Tidies up the intro slightly
- Mentions PyPy in the supported versions
- Links to options when mentioned
- Sets `default_role` so future documentation doesn't have to be as verbose
- Updates the language around comparing to `pep517-build` to mention that `pep517-build` isn't really a thing anymore regardless