### PR TITLE
Fix error message in ProjectBuilder

### DIFF
--- a/src/build/__init__.py
+++ b/src/build/__init__.py
@@ -153,7 +153,7 @@ class ProjectBuilder(object):
             self._build_system['requires'] = self._build_system.get('requires', []) + _DEFAULT_BACKEND['requires']
 
         if 'requires' not in self._build_system:
-            raise BuildException("Missing 'build-system.requires' in pyproject.yml")
+            raise BuildException("Missing 'build-system.requires' in pyproject.toml")
 
         self._backend = self._build_system['build-backend']
 


### PR DESCRIPTION
Looks like this accidentally says `pyproject.yml`.

This is purely cosmetic, of course.

One free t-shirt please?