### PR TITLE
Remove check for the existence of build-backend

### DIFF
--- a/tests/packages/test-bad-backend/pyproject.toml
+++ b/tests/packages/test-bad-backend/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = []
+build-backend = "nonsense_package"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -68,4 +68,4 @@ def test_isolation(tmp_dir, test_flit_path, mocker):
     mocker.patch('build.__main__._error')
 
     build.__main__.main([test_flit_path, '-o', tmp_dir, '--no-isolation'])
-    build.__main__._error.assert_called_with("Backend 'flit_core.buildapi' is not available")
+    build.__main__._error.assert_called_with("Backend 'flit_core.buildapi' is not available.")

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import copy
-import importlib
 import os
 import sys
 
@@ -111,14 +110,23 @@ def test_init(mocker, test_flit_path, legacy_path, test_no_permission, test_bad_
     with pytest.raises(build.BuildException):
         build.ProjectBuilder(test_bad_syntax_path)
 
-    mocker.patch('importlib.import_module', autospec=True)
-    importlib.import_module.side_effect = ImportError
 
-    # ImportError
+@pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
+def test_get_dependencies_missing_backend(packages_path, distribution):
+    bad_backend_path = os.path.join(packages_path, 'test-bad-backend')
+    builder = build.ProjectBuilder(bad_backend_path)
+
     with pytest.raises(build.BuildException):
-        build.ProjectBuilder(test_flit_path)
+        builder.get_dependencies(distribution)
+
+
+@pytest.mark.parametrize('distribution', ['wheel', 'sdist'])
+def test_build_missing_backend(packages_path, distribution, tmpdir):
+    bad_backend_path = os.path.join(packages_path, 'test-bad-backend')
+    builder = build.ProjectBuilder(bad_backend_path)
+
     with pytest.raises(build.BuildException):
-        build.ProjectBuilder(test_flit_path)
+        builder.build(distribution, str(tmpdir))
 
 
 def test_check_dependencies(mocker, test_flit_path):


### PR DESCRIPTION
This has been moved out of the ProjectBuilder constructor, since the ProjectBuilder is constructed before the isolated build environment is constructed and not executed IN the isolated environment, this check is not relevant.

Fixes GH-98.