### PR TITLE
setup.cfg: rename entrpoint script to pyproject-build

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ It is a simple build tool and does not perform any dependency management.
 
 .. note::
 
-   A ``python-build`` CLI script is also available, so that tools such as pipx_
+   A ``pyproject-build`` CLI script is also available, so that tools such as pipx_
    can use it.
 
 By default python-build will build the package in a isolated

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ package_dir =
 
 [options.entry_points]
 console_scripts =
-    python-build = build.__main__:entrypoint
+    pyproject-build = build.__main__:entrypoint
 
 [options.extras_require]
 doc =

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,15 +33,15 @@ _WHEEL = re.compile('.*.whl')
     [
         None,  # via code
         ['python', '-m', 'build'],  # module
-        ['python-build'],  # entrypoint
+        ['pyproject-build'],  # entrypoint
     ],
 )
 @pytest.mark.isolated
 def test_build(tmp_dir, monkeypatch, integration_path, project, args, call):
     monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'dummy')  # for the projects that use setuptools_scm
 
-    if call and call[0] == 'python-build' and 'PYTHONPATH' in os.environ:
-        pytest.skip('Running via PYTHONPATH, so the python-build entrypoint is not available')
+    if call and call[0] == 'pyproject-build' and 'PYTHONPATH' in os.environ:
+        pytest.skip('Running via PYTHONPATH, so the pyproject-build entrypoint is not available')
 
     path = os.path.join(integration_path, project)
     args = [path, '-o', tmp_dir] + args


### PR DESCRIPTION
Fixes #101

Signed-off-by: Filipe Laíns <lains@archlinux.org>