### PR TITLE
Upgrade isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,10 +17,10 @@ repos:
   rev: 20.8b1
   hooks:
   - id: black
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+- repo: https://github.com/PyCQA/isort
+  rev: 5.6.0
   hooks:
-  - id: isort
+    - id: isort
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: v1.9.0
   hooks:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,6 @@
 
 import build
 
-
 # -- Project information -----------------------------------------------------
 
 project = 'python-build'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,8 @@ build-backend = 'setuptools.build_meta'
 line-length = 127
 skip-string-normalization = true
 target-version = ['py38', 'py37', 'py36', 'py35', 'py27']
+
+[tool.isort]
+profile = "black"
+line_length = 127
+known_first_party = "build"

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,13 +69,6 @@ extend-ignore = E203
 ignore_missing_imports = True
 strict = True
 
-[isort]
-line_length = 127
-lines_between_types = 1
-lines_after_imports = 2
-known_first_party = build
-default_section = THIRDPARTY
-
 [coverage:run]
 omit =
     setup.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
 from setuptools import setup
 
-
 setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ import tempfile
 import filelock
 import pytest
 
-
 if sys.version_info[0] == 2:
     from urllib2 import urlopen
 else:

--- a/tests/packages/legacy/setup.py
+++ b/tests/packages/legacy/setup.py
@@ -2,7 +2,6 @@
 
 from setuptools import setup
 
-
 setup(
     name='legacy',
     version='1.0.0',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,7 +9,6 @@ import pytest
 
 import build.__main__
 
-
 _SDIST = re.compile('.*.tar.gz')
 _WHEEL = re.compile('.*.whl')
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,6 @@ import pytest
 import build
 import build.__main__
 
-
 if sys.version_info >= (3,):  # pragma: no cover
     build_open_owner = 'builtins'
 else:  # pragma: no cover

--- a/tests/test_projectbuilder.py
+++ b/tests/test_projectbuilder.py
@@ -11,10 +11,9 @@ import pytest
 
 import build
 
-
 if sys.version_info >= (3, 8):  # pragma: no cover
-    from importlib import metadata as importlib_metadata
     import email
+    from importlib import metadata as importlib_metadata
 
     email_message_from_string = email.message_from_string
 else:  # pragma: no cover


### PR DESCRIPTION
Move off from mirrors-isort that's now deprecated, and migrate
configuration to pyproject.toml