### PR TITLE
Improve tox.ini and integration tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
   hooks:
   - id: setup-cfg-fmt
     args: ["--min-py3-version", "3.5", "--max-py-version", "3.9"]
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: "3.8.4"
   hooks:
   - id: flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ where = src
 universal = 1
 
 [tool:pytest]
+junit_family = xunit2
 norecursedirs = tests/integration/*
 markers =
     isolated
@@ -79,3 +80,6 @@ source =
     src
     */site-packages
     *\site-packages
+
+[coverage:html]
+show_contexts = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,8 @@ strict = True
 [coverage:run]
 omit =
     setup.py
+    *bin/pyproject-build
+    *bin\pyproject-build.exe
 
 [coverage:paths]
 source =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,8 +59,8 @@ PYPY3_WIN_M = 'https://foss.heptapod.net/pypy/pypy/-/issues/3323 and https://fos
 
 
 def pytest_collection_modifyitems(config, items):
-    skip_int = pytest.mark.skip(reason='integration tests not run')
-    skip_other = pytest.mark.skip(reason='only integration tests are run')
+    skip_int = pytest.mark.skip(reason='integration tests not run (no --run-integration flag)')
+    skip_other = pytest.mark.skip(reason='only integration tests are run (got --only-integration flag)')
 
     if config.getoption('--run-integration') and config.getoption('--only-integration'):  # pragma: no cover
         raise pytest.UsageError("--run-integration and --only-integration can't be used together, choose one")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,24 +7,9 @@ import shutil
 import stat
 import subprocess
 import sys
-import tarfile
 import tempfile
 
-import filelock
 import pytest
-
-if sys.version_info[0] == 2:
-    from urllib2 import urlopen
-else:
-    from urllib.request import urlopen
-
-
-INTEGRATION_SOURCES = {
-    'dateutil': ('dateutil/dateutil', '2.8.1'),
-    'pip': ('pypa/pip', '20.2.1'),
-    'Solaar': ('pwr-Solaar/Solaar', '1.0.3'),
-    'flit': ('takluyver/flit', '2.3.0'),
-}
 
 
 def _setup():
@@ -65,8 +50,10 @@ def pytest_collection_modifyitems(config, items):
     if config.getoption('--run-integration') and config.getoption('--only-integration'):  # pragma: no cover
         raise pytest.UsageError("--run-integration and --only-integration can't be used together, choose one")
 
+    if len(items) == 1:  # do not require flags if called directly
+        return
     for item in items:
-        is_integration_file = os.path.basename(item.location[0]) == 'test_integration.py'
+        is_integration_file = is_integration(item)
         if PYPY3_WIN_VENV_BAD and item.get_closest_marker('isolated'):
             if not (is_integration_file and item.originalname == 'test_build') or (
                 hasattr(item, 'callspec') and '--no-isolation' not in item.callspec.params.get('args', [])
@@ -77,63 +64,17 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_int)
         elif config.getoption('--only-integration'):  # pragma: no cover
             item.add_marker(skip_other)
+    # run integration tests after unit tests
+    items.sort(key=lambda i: 1 if is_integration(i) else 0)
+
+
+def is_integration(item):
+    return os.path.basename(item.location[0]) == 'test_integration.py'
 
 
 @pytest.fixture
 def packages_path():
     return os.path.realpath(os.path.join(__file__, '..', 'packages'))
-
-
-@pytest.fixture(scope='session')
-def integration_path():
-    src_dir = os.path.realpath('.integration-sources')
-    dest = tempfile.mkdtemp(prefix='python-build-integration-')
-
-    if not os.path.exists(src_dir):
-        os.makedirs(src_dir)
-
-    # for python-build we use our own source directly
-    self_source = os.path.abspath(os.path.join(__file__, '..', '..'))
-    self_dest = os.path.join(dest, 'python-build')
-    if not os.path.exists(self_dest):
-        from build.env import fs_supports_symlink
-
-        if fs_supports_symlink():
-            os.symlink(self_source, self_dest)
-        else:  # pragma: no cover
-            os.makedirs(self_dest)
-            for target in ('pyproject.toml', 'setup.cfg', 'LICENSE', 'src'):
-                target_source = os.path.join(self_source, target)
-                target_dest = os.path.join(self_dest, target)
-                if os.path.isfile(target_source):
-                    shutil.copyfile(target_source, target_dest)
-                else:
-                    shutil.copytree(target_source, target_dest)
-
-    for target, (repo, version) in INTEGRATION_SOURCES.items():
-        with filelock.FileLock(os.path.join(src_dir, '{}.lock'.format(target))):
-            target_dest = os.path.join(dest, target)
-            if os.path.exists(target_dest):  # pragma: no cover
-                continue
-
-            tarball = os.path.join(src_dir, '{}.tar.gz'.format(target))
-            data = urlopen('https://github.com/{}/archive/{}.tar.gz'.format(repo, version)).read()
-            with open(tarball, 'wb') as f:
-                f.write(data)
-
-            tarfile.open(tarball, 'r:gz').extractall(dest)
-            shutil.move(os.path.join(dest, '{}-{}'.format(repo.split('/')[1], version)), target_dest)
-
-    yield dest
-
-    try:
-        os.unlink(self_dest)  # some implementations try to recursively remove the files inside the symlink
-        shutil.rmtree(dest)
-    except WindowsError:  # pragma: no cover
-        """
-        For some reason in some cases we don't have permission to remove
-        symlinks on windows, even though we created them?
-        """
 
 
 @pytest.fixture

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,55 +3,118 @@
 import os
 import os.path
 import re
+import shutil
 import subprocess
+import sys
+import tarfile
 
+if sys.version_info[0] == 3:
+    from urllib.request import Request, urlopen
+else:
+    from urllib2 import urlopen, Request
+
+import filelock
 import pytest
 
 import build.__main__
 
+INTEGRATION_SOURCES = {
+    'dateutil': ('dateutil/dateutil', '2.8.1'),
+    'pip': ('pypa/pip', '20.2.1'),
+    'Solaar': ('pwr-Solaar/Solaar', '1.0.3'),
+    'flit': ('takluyver/flit', '2.3.0'),
+}
+
 _SDIST = re.compile('.*.tar.gz')
 _WHEEL = re.compile('.*.whl')
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def get_project(name, tmp_path):
+    dest = tmp_path / name
+    if name == 'build':
+        # our own project is available in-source, just ignore development files
+
+        def _ignore_folder(_, filenames):
+            return [n for n in filenames if n in exclude or n.endswith('_cache') or n.endswith('.egg-info')]
+
+        exclude = '.tox', 'dist', 'build', '.git', '__pycache__'
+        shutil.copytree(ROOT, str(dest), ignore=_ignore_folder)
+        return dest
+
+    # for other projects download from github and cache it
+    tar_store = os.path.join(ROOT, '.integration-sources')
+    try:
+        os.makedirs(tar_store)
+    except OSError:  # python 2 has no exist_ok, and checking with exists is not parallel safe
+        pass  # just ignore, if the creation failed we will have another failure soon that will notify the user
+
+    github_org_repo, version = INTEGRATION_SOURCES[name]
+    tar_filename = '{}-{}.tar.gz'.format(name, version)
+    tarball = os.path.join(tar_store, tar_filename)
+    with filelock.FileLock(os.path.join(tar_store, '{}.lock'.format(tar_filename))):
+        if not os.path.exists(tarball):
+            url = 'https://github.com/{}/archive/{}.tar.gz'.format(github_org_repo, version)
+            request = urlopen(Request(url))
+            try:
+                with open(tarball, 'wb') as file_handler:
+                    shutil.copyfileobj(request, file_handler)
+            finally:
+                if sys.version_info[0] == 3:
+                    request.close()
+    with tarfile.open(tarball, 'r:gz') as tar_handler:
+        tar_handler.extractall(str(dest))
+    return dest
 
 
 @pytest.mark.parametrize(
-    ('project'),
+    'call',
     [
-        'python-build',
+        None,  # via code
+        [sys.executable, '-m', 'build'],  # module
+        ['pyproject-build'],  # entrypoint
+    ],
+    ids=['code', 'module', 'entrypoint'],
+)
+@pytest.mark.parametrize(
+    'args',
+    [[], ['-x', '--no-isolation']],
+    ids=['isolated', 'no_isolation'],
+)
+@pytest.mark.parametrize(
+    'project',
+    [
+        'build',
         'pip',
         'dateutil',
         'Solaar',
-        os.path.join('flit', 'flit_core'),
-    ],
-)
-@pytest.mark.parametrize(
-    ('args'),
-    [[], ['-x', '--no-isolation']],
-)
-@pytest.mark.parametrize(
-    ('call'),
-    [
-        None,  # via code
-        ['python', '-m', 'build'],  # module
-        ['pyproject-build'],  # entrypoint
+        'flit',
     ],
 )
 @pytest.mark.isolated
-def test_build(tmp_dir, monkeypatch, integration_path, project, args, call):
+def test_build(monkeypatch, project, args, call, tmp_path):
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv('SETUPTOOLS_SCM_PRETEND_VERSION', 'dummy')  # for the projects that use setuptools_scm
 
-    if call and call[0] == 'pyproject-build' and 'PYTHONPATH' in os.environ:
-        pytest.skip('Running via PYTHONPATH, so the pyproject-build entrypoint is not available')
-
-    path = os.path.join(integration_path, project)
-    args = [path, '-o', tmp_dir] + args
+    if call and call[0] == 'pyproject-build':
+        exe_name = 'pyproject-build{}'.format('.exe' if os.name == 'nt' else '')
+        exe = os.path.join(os.path.dirname(sys.executable), exe_name)
+        if os.path.exists(exe):
+            call[0] = exe
+        else:
+            pytest.skip('Running via PYTHONPATH, so the pyproject-build entrypoint is not available')
+    path = get_project(project, tmp_path)
+    pkgs = tmp_path / 'pkgs'
+    args = [str(path), '-o', str(pkgs)] + args
 
     if call is None:
         build.__main__.main(args)
     else:
         subprocess.check_call(call + args)
 
-    assert filter(_SDIST.match, os.listdir(tmp_dir))
-    assert filter(_WHEEL.match, os.listdir(tmp_dir))
+    pkg_names = os.listdir(str(pkgs))
+    assert filter(_SDIST.match, pkg_names)
+    assert filter(_WHEEL.match, pkg_names)
 
 
 def test_isolation(tmp_dir, test_flit_path, mocker):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    {py38, py37, py36, py35, py27, pypy3, pypy2}{, -path, -sdist, -wheel}
+    fix
+    {py39, py38, py37, py36, py35, py27, pypy3, pypy2}{, -path, -sdist, -wheel}
     type
     docs
 isolated_build = true
@@ -10,25 +11,42 @@ requires =
     virtualenv>=20.0.34
 
 [testenv]
-description = run the unit tests with pytest under {basepython}
+description =
+    run test suite with {basepython}
+    path: via PYTHONPATH
+    sdist: via source distribution
+    wheel: via wheel
 setenv =
+    COVERAGE_FILE = {envtmpdir}/.coverage
     path: TEST_MODE = path
     sdist: TEST_MODE = sdist
     wheel: TEST_MODE = wheel
 passenv =
     PYTEST_*
     PIP_*
-
 skip_install = path,sdist,wheel: false
 deps =
     path,sdist,wheel: -rrequirements-dev.txt
 extras =
     test
 commands =
-    pytest --cov --cov-config setup.cfg \
-      --cov-report=html:{envdir}/htmlcov \
+    pytest -rsx --cov --cov-config setup.cfg \
+      --cov-report=html:{envdir}/htmlcov --cov-context=test \
       --cov-report=xml:{toxworkdir}/coverage.{envname}.xml \
-      tests {posargs}
+      tests {posargs:--run-integration}
+
+[testenv:fix]
+description = run static analysis and style checks
+passenv =
+    HOMEPATH
+    PROGRAMDATA
+basepython = python3.9
+skip_install = true
+deps =
+    pre-commit>=2
+commands =
+    pre-commit run --all-files --show-diff-on-failure
+    python -c 'print("hint: run {envdir}/bin/pre-commit install to add checks as pre-commit hook")'
 
 [testenv:type]
 description = run type check on code base
@@ -46,6 +64,3 @@ deps =
 commands =
     sphinx-build -n -W docs/source {envtmpdir}
     python -c 'print("Documentation available under file://{envtmpdir}/index.html")'
-
-[pytest]
-junit_family = xunit2

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ description =
     wheel: via wheel
 setenv =
     COVERAGE_FILE = {envtmpdir}/.coverage
+    {py27, pypy2}: PYTHONWARNINGS = ignore:DEPRECATION::pip._internal.cli.base_command
     path: TEST_MODE = path
     sdist: TEST_MODE = sdist
     wheel: TEST_MODE = wheel


### PR DESCRIPTION
tox.ini:

- include py39
- add a tox environment for running the pre-commit check
- append description for the path, sdist, wheel variants
- use github over gitlab for all pre-commit checks
- enable coverage context collection and rendering in html
- move coverage temp files to the envtmpdir
- run integration tests by default

integration tests:

- Make it parallel safe
- Only download as much as needed instead of all
- Move acquisition of the pkgs to where the test is
- Allow running them without the --run-integration flag if only pytest target
- Wrap URL into Request to make it work behind proxy firewall too (SSL_CERT_FILE set)
- building via pyproject-build is validated via existance of the console entrypoint rather than the existance of the PYTHONPATH variable (more accurate, and IDE friendly)

Signed-off-by: Bernát Gábor <bgabor8@bloomberg.net>